### PR TITLE
Player momentum

### DIFF
--- a/game/rule-book.md
+++ b/game/rule-book.md
@@ -169,6 +169,14 @@ Stat Groups can be further organized into Stat Quadrants. There are four Stat Qu
 The highest-level player stats are the Player's rolled up Skill Level, Health, and Quality Percentage.
 The Player Skill level is the sum of all the Player's individual skill levels. The Health is the *lowest* of all their individual Health Stats, and the Player's Quality Percentage is the *average* of all their individual Quality Stats.
 
+### Player Momentum
+
+Player momentum is a composite stat that reflects the pace at which of the player's learning is accelerating. It's calculated using the following formula:
+
+*Total SP Earned in Current Week / (Three Week Moving SP Average * 100)* [^1]
+
+The Player Momentum is expressed as a percentage. Anything over 100% indicates the player's rate of learning is accelerating, anything under 100% means it is decelerating.
+
 ## Game Objects
 
 
@@ -376,3 +384,7 @@ Challenges will include (but not be limited to):
 ### 1 - Ingame
 
 ### 2 - Postgame
+
+---
+
+[^1]: Three Week Moving SP Average = (Total SP earned in the previous 3 weeks) / 3


### PR DESCRIPTION
Addresses #64 

How do we set the players' pace? 

In addressing this issue, I took the following things into consideration:

**Time-based Pacing**
- It's challenging for Level Builders to tie players leveling up to a certain time frame. Certain players will be faster/slower than others. As player support gets better, players will move faster, as admissions criteria changes player's pace will change...etc. Setting a specific time-based pace that applies to all risks boring the fastest players, and over-stressing the slowest ones. 
- Setting a pace using time: i.e. you should learn X by this time, smacks of our how our current learning system works. It take autonomy away from the player, and puts the locus of authority/control more on the game design. This is too much responsibility, and really hard to do well at scale and in a generalized way. 

Making this assumption I set aside any temporal-based pacing as a core game mechanic. Certain challenges may choose to have time constraints on them, but that's a different matter. Players can freely choose to step into these challenges and also choose _when_ to take them on. It's very different to say "You should be a level 3 db by week 10", than saying "You I challenge you to spend  3 days building a twitter clone". 

**Syncing challenges**

From the DBC experience, there's something very special that happens in a room when everyone is tackling the same challenge:
- Knowledge/experience is exchanged more efficiently and effectively
- It's easier for mentors to help because lessons / teaching points are repeated, and there's a lot less context switching going on

I considered several game mechanics that would guide players into _syncing_ the challenges they are working on. Some of the mechanics I considered:
- Terrain elements that are time-released and mandatory: For example: a group project that is _released_ in week 5. Everyone has to do it. 
- Skill levels that are unlocked based on time, not previously unlocked skill levels. For example: database level 3 becomes available in week 10. So, theoretically, a bunch of players get excited about that and start tackling db level 3 challenges and learning is synced. The idea here is that how deep a player goes down a certain skill would be self paced, but switching to new skills would be POD paced.

The more I dug into how these mechanics would work, the more they seemed clunky to me. In the end I tossed them out. Instead, terrain designers have the option of setting min-player to a high enough number for certain challenges to enforce group work. This would sync learning across 4 maybe 6 players at the same time. And I left the POD syncing outside of the game mechanics. This needs to be addressed as a Player Support issue. I see it as a learning strategy that we can support and encourage PODs to adopt. #94

**Balancing Group v.s. Individual Learning**

**Non-coersion**

In the end, I opted for a non-coersive game mechanic: the core principle here is to surface information and data about pace to the player, and let them decide what do with that feedback. I added a "Player momentum" stat that tracks the rate of learning. I imagine that player support can use that stat and others, and surface useful information that can guide players/pods in pacing.

For example: 
- You have completed 40% of the terrain in 35% of the 40 weeks.
- You are ahead of 40% of other players by this stage of the game
- Your pod momentum is in the lowest 25% of all pods.  
- Your momentum is 10% slower than your POD's average momentum

PODs might choose to set momentum goals, or skill level goals. They might choose to maintain "maximum gaps" between highest and lowest level players. They might choose to simply keep a positive average POD momentum without setting goals (i.e. expressing their goals through pace and not actual levels). PODs might choose to decide on a common set of challenges that they all attempt for the week in order to sync their learning. Perhaps PODs decided to break into crews of four or five players, and set goals and stretch goals as a crew.

All this seems like a player support issue and not a game mechanic. So far, it actually seems that the very idea of a POD itself might be a player support structure and not a core game structure #89 
