### PR TITLE
Wg/ Define terrain-criteria #118

### DIFF
--- a/wg-terrain-criteria.md
+++ b/wg-terrain-criteria.md
@@ -24,6 +24,8 @@ What do learners need to succeed in LG?
  * You can work skillfully with conflict
  * You can work with others to generate inquiry and insights 
  * You can regulate drama/emotional intensity
+ * You can pair up
+ * You can pair down
  
 * You can adapt to your teammates’ work and communication styles 
  * You can integrate your work with other people’s work
@@ -83,9 +85,10 @@ What do learners need to succeed in LG?
 
 
 **4.) You are perceived as valuable to the business/company you work for**
+* You can state your role's purpose in the company
 * You can demonstrate your contributions to your boss/co-workers
 * You can make meaningful contributions to the bottom line 
-* You can function within work constraints - show up on time
+* You can function within work constraint -- e.g., show up on time
 * You can identify and describe your contributions to the company’s OKRs, KPIs, or other metrics
 * You can negotiate regular work reviews
 * You can maintain a high level of productivity
@@ -105,7 +108,7 @@ What do learners need to succeed in LG?
 * You can identify what you need to learn to advance your career and your effectiveness.
 * You can find the resources that enable you to consciously increase your rate of learning.
 * You can make a learning plan tailored to your learning styles, the available resources, and your timeline. 
-* You can remove obstacles that stand in the way of your advancement both professionally and personally.
+* You can address obstacles that stand in the way of your advancement both professionally and personally.
 
 
 ##Success as a Player at Learners Guild means… 


### PR DESCRIPTION
This list was created to define what learners need in order to succeed in the professional world and to succeed in LG. 

The idea is to have a criteria for all skills -- if a skill does not help move a learner toward these goals, it is not essential. If our skills, combined, miss any of these criteria, they are incomplete. 

This list defines the "end state" of a learner who has finished LG. In a self-directed learning environment, Learners need to have a crystal clear picture of where they need to end up. This list gives them a focus. "I am learning X because it gets me to this goal." 

In some conversations I have called this list a "razor" -- run everything up against this list. If it does not meet these goals, it gets cut. We can add it back later if we have extra time in the curricula. 

It is easy for our skills list to grow really long. Its easy to put things into a curricula because they are "good to know" but not essential. This temptation is what causes curricula to lose their focus. It overstuffs a curricula and creates distractions for learners. 

Next, this list is discipline for us to make sure we are giving learners everything they need to learn -- not just what we want to teach, but what the world demands that learners know. For example, as Simon, Adam and I did the first version, we realized that none of us had thought through the skills a learner will need to keep a job -- like finding belonging is a system and finding mentors. 

Last note -- there are somethings on this list that we may not want to take on,or that are better for partnering organizations to do, like interviewing skills and resume writing. We don't have to be the ones providing the support, but we need a clear path for every learner to get that knowledge. 
